### PR TITLE
Fixes #18: Adds main, module, types keys in package.json

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -12,10 +12,14 @@
     "url": "git+https://github.com/tryretool/retoolrpc.git"
   },
   "license": "MIT",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Fixes #18 

This adds the appropriate `main`, `module`, and `types` keys to retoolrpc's javascript's package.json such that typechecking works correctly under `"module": "CommonJS"` and `"moduleResolution": "bundler"`. See https://github.com/noahsark769/retoolrpc-typescript-issue and #18 for more discussion about this issue.