### PR TITLE
fix: use `unref()` to allow graceful shutdown

### DIFF
--- a/javascript/src/utils/polling.ts
+++ b/javascript/src/utils/polling.ts
@@ -6,7 +6,8 @@ const CONNECTION_ERROR_RETRY_MAX_MS = 1000 * 60 * 10 // 10 minutes
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
-    setTimeout(resolve, ms)
+    const timeout = setTimeout(resolve, ms)
+    timeout.unref()
   })
 }
 

--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -12,6 +12,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "lib": ["ESNext"]
   },
   "ts-node": {
     // these options are overrides used only by ts-node


### PR DESCRIPTION
Closes #23 but an explicit stop would still be nice along side this

> When called, the active Timeout object will not require the Node.js event loop to remain active. If there is no other activity keeping the event loop running, the process may exit before the Timeout object's callback is invoked. Calling timeout.unref() multiple times will have no effect.
> 
> — https://nodejs.org/api/timers.html#timeoutunref
