### PR TITLE
adding an injectable error handler for listen()

### DIFF
--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -3,3 +3,4 @@ yarn-error.log
 .vscode
 dist
 tsconfig.tsbuildinfo
+package-lock.json

--- a/javascript/src/rpc.ts
+++ b/javascript/src/rpc.ts
@@ -76,13 +76,13 @@ export class RetoolRPC {
   /**
    * Asynchronously starts listening for incoming Retool function invocations.
    */
-  async listen(): Promise<void> {
+  async listen(onError?: (error: unknown) => Promise<void>): Promise<void> {
     this._logger.info('Starting RPC agent')
     const registerResult = await loopWithBackoff(this._pollingIntervalMs, this._logger, () => this.registerAgent())
     if (registerResult === 'done') {
       this._logger.info('Agent registered')
       this._logger.info('Starting processing query')
-      loopWithBackoff(this._pollingIntervalMs, this._logger, () => this.fetchQueryAndExecute())
+      loopWithBackoff(this._pollingIntervalMs, this._logger, () => this.fetchQueryAndExecute(), onError)
     }
   }
 


### PR DESCRIPTION
We use retoolRPC and occasionally there are socket hang ups and other network issues that trigger the default error logging behaviour in the polling listen method.

This is fine, however it does make for some messy logging situations. The actual reason for the failure is included so we _could_ filter on these messages. But one other way would be to allow users the ability to decide what they want to do on an error instead. This shouldn't interfere with the operation of anything out of the box or by default, but it does give the consumer of the SDK the ability to back-off at their discretion, or to just propagate a failure and exit.

I also added `package-lock.json` to the `.gitignore` file because you guys use yarn.