### PR TITLE
Add permissions support to registerModel

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retoolrpc",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "TypeScript package for Retool RPC",
   "keywords": [],
   "homepage": "https://github.com/tryretool/retoolrpc#readme",

--- a/javascript/src/addons/sequelize.ts
+++ b/javascript/src/addons/sequelize.ts
@@ -7,6 +7,10 @@ type RegisterModelArgs = {
   readAttributes?: string[]
   writeAttributes?: string[]
   findByAttributes?: string[]
+  permissions?: {
+    groupNames?: string[]
+    userEmails?: string[]
+  }
 }
 
 export declare class MyMixinInterface {
@@ -35,6 +39,7 @@ function registerModel({
   readAttributes,
   writeAttributes,
   findByAttributes,
+  permissions,
 }: RegisterModelArgs & { rpc: RetoolRPC }) {
   const modelName = capitalize(model.name)
   // this will give us not just the name of the attribute, but also their type
@@ -57,6 +62,7 @@ function registerModel({
   rpc.register({
     name: `${modelName} > create`,
     arguments: writeAttributeArgs,
+    permissions,
     implementation: async (args) => {
       if (typeof args !== 'object' || Array.isArray(args)) {
         throw 'attributes must be an object'
@@ -76,6 +82,7 @@ function registerModel({
       primaryKey: { type: 'string', required: true },
       ...writeAttributeArgs,
     },
+    permissions,
     implementation: async ({ primaryKey, ...attributes }) => {
       return model.update(attributes, {
         where: {
@@ -91,6 +98,7 @@ function registerModel({
       findAttributes: { type: 'dict', required: true },
       ...writeAttributeArgs,
     },
+    permissions,
     implementation: async ({ findAttributes, ...writeAttributes }) => {
       // Note: this is susceptible to race condition if there is no unique index
       // on the find attributes. It's the user's responsibility to avoid
@@ -115,6 +123,7 @@ function registerModel({
       offset: { type: 'number' },
       limit: { type: 'number' },
     },
+    permissions,
     implementation: async ({ offset, limit }) => {
       return model.findAll({
         attributes: readAttributes,
@@ -130,6 +139,7 @@ function registerModel({
     arguments: {
       primaryKey: { type: 'string', required: true },
     },
+    permissions,
     implementation: async ({ primaryKey }) => {
       return model.findByPk(primaryKey, {
         attributes: readAttributes,
@@ -141,6 +151,7 @@ function registerModel({
   rpc.register({
     name: `${modelName} > findBy`,
     arguments: findByAttributeArgs,
+    permissions,
     implementation: async (attributesValues) => {
       return model.findAll({
         where: attributesValues,

--- a/javascript/src/version.ts
+++ b/javascript/src/version.ts
@@ -1,1 +1,1 @@
-export const RetoolRPCVersion = '0.1.7'
+export const RetoolRPCVersion = '0.1.8'


### PR DESCRIPTION
## Summary
- Adds an optional `permissions` field to `RegisterModelArgs` type, matching the existing `RegisterFunctionSpec` permissions shape (`groupNames`, `userEmails`)
- Forwards `permissions` to all 6 `rpc.register()` calls generated by `registerModel` (create, update, createOrUpdate, findAll, findByPk, findBy)
- Fully backward compatible — existing callers without `permissions` are unaffected

## Context
This is Phase 1 of [PLAT-907](https://linear.app/retool/issue/PLAT-907/add-permissions-to-experimentexperimentstrategy-registermodel-update). The `Experiment` and `ExperimentStrategy` models are currently registered without permissions, exposing unrestricted CRUD operations. This change enables callers to lock down model operations to specific groups/users.

## Test plan
- [x] Build passes (`yarn build`)
- [ ] Existing tests pass
- [ ] Phase 2 PR in retool_development will consume this to add permissions to Experiment/ExperimentStrategy models

🤖 Generated with [Claude Code](https://claude.com/claude-code)